### PR TITLE
Graph api key initialization

### DIFF
--- a/sdk/examples/index.ts
+++ b/sdk/examples/index.ts
@@ -10,6 +10,7 @@ import {
     getXCAmpleController,
     getXCRebases,
     getXCAmpleToken,
+    queries,
 } from '../src'
 
 async function printAMPLData(chainID: number) {
@@ -105,7 +106,12 @@ async function printXCAmpleData(chainID: number) {
 }
 
 async function run() {
-    await printAMPLData(1)
+    if (process.argv.length < 3) {
+      console.log('provide API Key as command line argument to run mainnet example')
+    } else {
+      queries.initializeApiKey(process.argv[2])
+      await printAMPLData(1)
+    }
     await printXCAmpleData(43114)
     await printAMPLData(42)
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ampleforthorg/sdk",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "description": "Typescript SDK for the Ampleforth Protocol",
     "license": "GPL-3.0-or-later",
     "main": "dist/src/index.js",

--- a/sdk/src/queries/client.ts
+++ b/sdk/src/queries/client.ts
@@ -9,15 +9,26 @@ export const GRAPH_BASE_URL = 'https://api.thegraph.com/subgraphs/name'
 
 export const GRAPH_ENDPOINTS: GraphEndpointsMapping = {
     // chainID => endpoint
-    1: 'https://gateway.thegraph.com/api/09f032e5d7ba7cc9725796c9ee511c17/subgraphs/id/3KgoMxpMHJsLK2R4W9hrF6S7WTYdcH9UW9vtnsGumY4s',
     42: `${GRAPH_BASE_URL}/ampleforth/ampleforth-core-kovan`,
     43114: `${GRAPH_BASE_URL}/ampleforth/ampleforth-core-avalanche`,
 }
 
 export const MAX_PER_PAGE = 500
 
+export const AMPLEFORTH_DAO_SUBGRAPH_ID = '3KgoMxpMHJsLK2R4W9hrF6S7WTYdcH9UW9vtnsGumY4s'
+
+export const GRAPH_GATEWAY_URL = 'https://gateway.thegraph.com'
+
+export const initializeApiKey = (apiKey: string): void => {
+  GRAPH_ENDPOINTS[1] = `${GRAPH_GATEWAY_URL}/api/${apiKey}/subgraphs/id/${AMPLEFORTH_DAO_SUBGRAPH_ID}`
+}
+
 export const initializeClient = (chainID = 1): Client => {
-    if (GRAPH_ENDPOINTS[chainID] === null) {
+    if (GRAPH_ENDPOINTS[chainID] === undefined) {
+      if (chainID === 1) {
+        console.log('chainid 1')
+        throw new Error(`No graph endpoint found for chainID:1. Try updating your API Key with queries.initializeApiKey. See https://thegraph.com/studio/apikeys/ if you don't have an API Key`)
+      }
         throw new Error(`No graph endpoint found for chainID:${chainID}`)
     }
 

--- a/sdk/src/queries/client.ts
+++ b/sdk/src/queries/client.ts
@@ -26,7 +26,6 @@ export const initializeApiKey = (apiKey: string): void => {
 export const initializeClient = (chainID = 1): Client => {
     if (GRAPH_ENDPOINTS[chainID] === undefined) {
       if (chainID === 1) {
-        console.log('chainid 1')
         throw new Error(`No graph endpoint found for chainID:1. Try updating your API Key with queries.initializeApiKey. See https://thegraph.com/studio/apikeys/ if you don't have an API Key`)
       }
         throw new Error(`No graph endpoint found for chainID:${chainID}`)

--- a/sdk/src/queries/index.ts
+++ b/sdk/src/queries/index.ts
@@ -1,4 +1,4 @@
-import { initializeClient, MAX_PER_PAGE } from './client'
+import { initializeApiKey, initializeClient, MAX_PER_PAGE } from './client'
 import { GET_ORACLE_DATA, GET_PROVIDER_REPORTS } from './oracle'
 import { GET_POLICY_DATA, GET_REBASES } from './policy'
 import { GET_TOKEN_DATA, GET_TOKEN_BALANCES, GET_TOKEN_APPROVAL } from './token'
@@ -10,6 +10,7 @@ import {
 } from './xc_token'
 
 export {
+    initializeApiKey,
     initializeClient,
     MAX_PER_PAGE,
     GET_ORACLE_DATA,


### PR DESCRIPTION
Requires SDK users to provide their own Graph API Keys to queries the Ampleforth DAO Hosted Subgraph:
- exports new `queries.initializeApiKey` method to provide such a key
- alerts user of necessity to do so with new errors
- examples updated to reflect this

Note: holding merge for needed updates to token-geyser-v2 for initializing domain authorized ApiKey